### PR TITLE
Drop --pages=1 inkscape flag (fixes #4)

### DIFF
--- a/_extensions/tikz/tikz.lua
+++ b/_extensions/tikz/tikz.lua
@@ -235,9 +235,11 @@ $body$
           "\nTikZ Code:\n" .. code)
       end
 
-      -- Convert PDF to SVG using Inkscape
+      -- Convert PDF to SVG using Inkscape.
+      -- Note: --pages=N (Inkscape 1.2+) is omitted because the standalone
+      -- class always produces a single-page PDF, and dropping it preserves
+      -- compatibility with Inkscape 1.0/1.1 (issue #4).
       local args = {
-        '--pages=1',
         '--export-area-drawing',
         '--export-type=svg',
         '--export-plain-svg',


### PR DESCRIPTION
## Summary
- Removes the `--pages=1` argument from the inkscape PDF→SVG invocation in `_extensions/tikz/tikz.lua`.
- `--pages` was introduced in Inkscape 1.2 (May 2022); 1.0/1.1 users (Ubuntu 20.04/22.04 LTS, Debian Bullseye, etc.) hit `Unknown option --pages=1` and rendering failed (see [#4](https://github.com/danmackinlay/quarto_tikz/issues/4)). The standalone document class always produces a single-page PDF and Inkscape's default already converts that page, so the flag was unnecessary.

## Test plan
- [x] `quarto render example.qmd` succeeds locally on Inkscape 1.4.3
- [x] Both `stick-figure.svg` and `my-fancy-diagram.svg` are generated and embedded in `example.html`
- [ ] (Reporter) Confirm rendering now works on Inkscape 1.0/1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)