### PR TITLE
Set TEXINPUTS for shared \input / \usepackage (closes #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,7 @@ If you're using version control, you will want to check in this directory.
 
 ## Using
 
-Create a code block with class `.tikz`.
-
-# Simple TikZ Diagram
-
-Here is a simple TikZ diagram without additional packages or complex features:
+Create a code block with class `.tikz`. Here is a simple TikZ diagram without additional packages or complex features:
 
 ````markdown
 ```{.tikz}
@@ -83,30 +79,112 @@ Here is the source code for a minimal example: [example.qmd](example.qmd).
 
 ## Dependencies
 
-* inkscape
+You need both `pdflatex` (TeX Live or MacTeX) and `inkscape` (≥ 1.0)
+installed and on your `PATH`. The filter shells out to `pdflatex` to
+build a PDF and then to Inkscape to convert that PDF to SVG.
 
-## Known bugs
+## Caching
 
-- all classes and ids are striped from the output figure if you specify them from inside the tikz block, despite my best efforts to explicitly attach them to the generated Figure.
-  Thus you cannot refer to the figure in the text if you create a figure by specifying a caption in the tikz block.
-  Probably this could be helped by usig the new [FloatRefTarget](https://quarto.org/docs/prerelease/1.4/lua_changes.html)
-- But if you use quarto’s fenced divs and give it a name like `#fig-my-diagram` things work fine; see [example.qmd](example.qmd).
+Compiling TikZ via `pdflatex` and Inkscape is slow, so the filter has an
+optional content-addressed cache.
 
+Enable it from your project's `_quarto.yml` (or any single document's
+front-matter):
+
+```yaml
+tikz:
+  cache: true
+```
+
+By default, cached SVGs are written to a per-user cache directory:
+
+- Linux/macOS: `$XDG_CACHE_HOME/tikz-diagram-filter/` (falls back to
+  `~/.cache/tikz-diagram-filter/` if `XDG_CACHE_HOME` is unset).
+- Windows: `%USERPROFILE%\.cache\tikz-diagram-filter\`.
+
+Cache keys are the SHA1 of the TikZ code together with any per-block
+options, so editing either invalidates the entry.
+
+You can override the location with `tikz.cache-dir: <path>`, but doing so
+scatters per-directory cache folders across the tree. **Leaving
+`cache-dir` unset and using the default user-level cache is the
+recommended setup.**
+
+Cleanup today is manual — `rm -rf` the cache dir occasionally, or
+`find <cache-dir> -mtime +30 -delete` if you want a time-based sweep.
+
+Known follow-ups (PRs welcome):
+
+- [#9](https://github.com/danmackinlay/quarto_tikz/issues/9) — include
+  the diagram basename in the cache filename so a directory listing is
+  human-diagnosable.
+- [#10](https://github.com/danmackinlay/quarto_tikz/issues/10) — touch
+  cache entries on hit so an external `find -mtime`-based GC reflects
+  actual last use.
+
+A proper Quarto language engine would handle this more cleanly than a
+homegrown cache, but writing one is more work than this project can
+justify right now.
+
+## Debugging a diagram
+
+When a TikZ block silently produces something wrong (or fails to
+compile), the quickest way to diagnose it is to look at the intermediate
+`.tex`, `.pdf` and `.log` files that `pdflatex` actually saw. The
+filter can preserve those for inspection, but **only with caching
+switched off** (see below):
+
+```yaml
+# in the offending document's front-matter, temporarily
+tikz:
+  cache: false
+  save-tex: true
+  tex-dir: tikz-tex   # any path; defaults to 'tikz-tex'
+```
+
+Re-render the document and inspect
+`<tex-dir>/<filename>/<filename>.{tex,pdf,svg,log}`. Running `pdflatex
+<filename>.tex` by hand from inside that directory reproduces the exact
+compilation, and the `.log` is usually enough to spot the problem.
+
+`cache: true` and `save-tex: true` are mutually exclusive: a cache hit
+short-circuits compilation, so no intermediates would ever be written.
+If both are set, the filter logs a warning and disables `save-tex`. So
+debugging is a brief detour: switch caching off, debug, then revert.
+
+`tex-dir` is otherwise inert under `cache: true`. Stale `tikz-tex/`
+directories from previous debugging sessions are safe to delete —
+nothing in the rendered HTML references them. You'll usually want to add
+your `tex-dir` to `.gitignore`.
 
 ## PDF output
 
-This does produce PDFs which can be included in PDF output; I wonder if we could shortcut the PDF rendering and just output as plain LaTeX in that case to integrate into the main LaTeX rendering workflow?
-I’m not suite sure how to handle the TikZ libraries in that case.
+The extension always converts each diagram to SVG (via `pdflatex` →
+Inkscape) and embeds that. There is currently no special path for PDF
+output (e.g. directly embedding the intermediate PDF, using `lualatex`
+for richer Unicode coverage, or accepting custom LaTeX templates). For
+that broader set of features see the discussion and proposed work in
+[#5](https://github.com/danmackinlay/quarto_tikz/issues/5). PRs welcome.
 
-Pull requests welcome.
+## Known bugs
 
-## Efficiency
+Figure attributes set inside the TikZ block (via `%%| fig-attr:`,
+`label:`, `name:`) don't always survive the round-trip into the rendered
+output. The reliable pattern is to wrap the block in a Quarto fenced
+div, which is what the bundled [`example.qmd`](example.qmd) does:
 
-This filter has optional execution caching.
-If you use that, make sure you clean it up occasionally, as it will fill up your disk with diagrams.
+````markdown
+::: {#fig-my-diagram}
+```{.tikz}
+%%| filename: my-diagram
+\begin{tikzpicture}…\end{tikzpicture}
+```
 
-A better implementation would use a language cache like other engines in quarto.
-However, developing a a whole tikz language engine feels like a lot more work than I can justify for the current project.
+Caption goes here.
+:::
+````
+
+This makes `@fig-my-diagram` cross-references work correctly.
 
 
 ## Upgrading from Previous Versions
@@ -233,6 +311,38 @@ The extension now uses `pdflatex` and `inkscape` instead of the older `dvisvgm` 
 There were certain advantages to that renderer; I wonder if we should support switchable backends?
 
 Anyway, you need to ensure that both `pdflatex` and `inkscape` are installed and accessible in your system's PATH. If not, install them to avoid rendering issues.
+
+## Configuration reference
+
+Document- or project-level options (set under `tikz:` in the YAML
+front-matter or `_quarto.yml`):
+
+- `cache` — boolean, default `false`. Enable the on-disk SVG cache.
+- `cache-dir` — path. Defaults to `$XDG_CACHE_HOME/tikz-diagram-filter`
+  (or the per-user cache equivalent on your platform). Override only if
+  you have a specific reason; otherwise leave unset.
+- `save-tex` — boolean, default `false`. Preserve intermediate
+  `.tex`/`.pdf`/`.log` files for debugging. Ignored (with a warning)
+  when `cache: true`.
+- `tex-dir` — path, default `tikz-tex`. Where preserved intermediates
+  land when `save-tex` is on.
+
+Per-block directives (set inside the TikZ code block as `%%| key:
+value` lines, as in [`example.qmd`](example.qmd)):
+
+- `filename` — basename for the generated `.tex`/`.pdf`/`.svg`. Defaults
+  to a hash of the code.
+- `caption` — figure caption (Markdown).
+- `alt` — image alt text.
+- `fig-attr:` — nested block of Pandoc figure attributes (`id`,
+  `class`, etc.).
+- `additionalPackages` — extra `\usepackage{…}` lines added to the
+  preamble of the synthesized LaTeX document.
+- `header-includes` — additional raw LaTeX inserted into the preamble.
+
+Attributes prefixed with `fig-`, `image-`/`img-`, or `opt-` on the code
+block fence are routed to the figure, the image, or the per-block
+options respectively.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,42 @@ This should appear in the output as an image
 
 ![](/images/stick-figure.svg)
 
+## Sharing styles between diagrams
+
+If you have a `\tikzset` or a `\usepackage` block that you want to reuse
+across many diagrams, you can put it in a separate file alongside your
+`.qmd` and `\input` (or `\usepackage`) it from each TikZ block. The
+extension sets `TEXINPUTS` before invoking `pdflatex` so that lookups
+resolve in this order:
+
+1. The directory containing the source `.qmd`.
+2. The extension's own directory (`_extensions/tikz/`), so that you can
+   ship shared style files together with the extension itself.
+3. Your system's default LaTeX search path (so `\usepackage{tikz}` etc.
+   continue to work as normal).
+
+For example, drop a `shared-styles.tex` next to your `.qmd`:
+
+```latex
+% shared-styles.tex
+\tikzset{myedge/.style={->, red, thick}}
+```
+
+Then use it from any TikZ block:
+
+````markdown
+```{.tikz}
+\input{shared-styles.tex}
+\begin{tikzpicture}
+  \draw[myedge] (0,0) -- (2,0);
+\end{tikzpicture}
+```
+````
+
+The same mechanism works for a bundled `.sty` file (e.g.
+`\usepackage{shared-styles}`) placed either next to the `.qmd` or
+inside `_extensions/tikz/`.
+
 ## Example
 
 Here is the source code for a minimal example: [example.qmd](example.qmd).

--- a/_extensions/tikz/_extension.yml
+++ b/_extensions/tikz/_extension.yml
@@ -1,6 +1,6 @@
 title: Tikz
 author: dan mackinlay
-version: 1.0.0
+version: 1.1.0
 quarto-required: ">=1.3.0"
 contributes:
   filters:

--- a/_extensions/tikz/tikz.lua
+++ b/_extensions/tikz/tikz.lua
@@ -220,13 +220,21 @@ $body$
       )
       write_file(tikz_file, tex_code)
 
-      -- Execute the LaTeX compiler:
-      local success, latex_result = pcall(
-        pandoc.pipe,
-        'pdflatex',
-        { '-interaction=nonstopmode', tikz_file },
-        ''
-      )
+      -- Execute the LaTeX compiler with TEXINPUTS so blocks can \input or
+      -- \usepackage shared files from the qmd directory or the extension dir.
+      -- with_environment replaces the entire env, so we merge our override
+      -- onto a copy of the current env to preserve PATH and friends.
+      local env = pandoc.system.environment()
+      env.TEXINPUTS = conf.texinputs
+      local success, latex_result = pcall(function()
+        return pandoc.system.with_environment(env, function()
+          return pandoc.pipe(
+            'pdflatex',
+            { '-interaction=nonstopmode', tikz_file },
+            ''
+          )
+        end)
+      end)
       if not success then
         local log_file = base_filename .. ".log"
         local log_content = read_file(log_file) or ""
@@ -336,6 +344,49 @@ local function code_to_figure(conf)
   end
 end
 
+-- Resolve a (possibly relative) path to an absolute path. Necessary because
+-- pdflatex is launched from a temporary working directory, so any TEXINPUTS
+-- entries that started life as relative paths against the qmd's cwd would
+-- otherwise resolve to nothing.
+local function absolutize(p)
+  if not p or p == '' then return nil end
+  if pandoc.path.is_absolute(p) then return p end
+  local cwd = os.getenv('PWD') or os.getenv('CD') or '.'
+  return pandoc.path.normalize(pandoc.path.join { cwd, p })
+end
+
+-- Build TEXINPUTS so TikZ blocks can \input shared files from the qmd
+-- directory and from the extension's own directory, while preserving any
+-- existing TEXINPUTS and the system default search path.
+local function build_texinputs()
+  -- Path separator: ':' on Unix, ';' on Windows.
+  local sep = (pandoc.system.os == 'windows') and ';' or ':'
+
+  -- Directory of the source qmd. Prefer quarto.doc.input_file; fall back
+  -- to PANDOC_STATE.input_files[1] for older Quarto / plain-pandoc use.
+  local source_file = (quarto and quarto.doc and quarto.doc.input_file)
+    or (PANDOC_STATE and PANDOC_STATE.input_files and PANDOC_STATE.input_files[1])
+  local source_dir = source_file
+    and pandoc.path.directory(absolutize(source_file))
+    or nil
+
+  -- Directory of this filter script (so the extension can ship shared
+  -- .tex/.sty files alongside tikz.lua).
+  local ext_dir = PANDOC_SCRIPT_FILE
+    and pandoc.path.directory(absolutize(PANDOC_SCRIPT_FILE))
+    or nil
+
+  -- Preserve any pre-existing TEXINPUTS from the user's environment.
+  local existing = os.getenv('TEXINPUTS')
+
+  local parts = {}
+  if source_dir then parts[#parts + 1] = source_dir end
+  if ext_dir and ext_dir ~= source_dir then parts[#parts + 1] = ext_dir end
+  if existing and existing ~= '' then parts[#parts + 1] = existing end
+  -- Trailing separator => include system defaults.
+  return table.concat(parts, sep) .. sep
+end
+
 -- Function to configure the filter based on metadata and format
 local function configure (meta, format_name)
   local conf = meta.tikz or {}
@@ -379,6 +430,7 @@ local function configure (meta, format_name)
     image_cache = image_cache,
     save_tex = save_tex,
     tex_dir = tex_dir,
+    texinputs = build_texinputs(),
   }
 end
 


### PR DESCRIPTION
## Summary

- Set `TEXINPUTS` before invoking `pdflatex` so TikZ blocks can `\input{shared-styles.tex}` or `\usepackage{shared-styles}` from the qmd directory and from the extension's own directory. System default texmf paths still resolve.
- Bump version to `1.1.0` (backward-compatible feature add).
- Document the new feature in `README.md` under "Sharing styles between diagrams".
- Rewrite the rest of the README in the same PR: a real "Caching" section (default location, override, manual cleanup, follow-ups #9/#10), a new "Debugging a diagram" section (`save-tex` workflow + mutual exclusion with caching), a fact-based "PDF output" pointer to #5, a trimmed "Known bugs" section, and a compact "Configuration reference" at the end. Also clarifies `pdflatex` is a required dependency.

Closes #6.

### Notes on the implementation

- `TEXINPUTS` is computed once in `configure()` and stored on `conf`, since `quarto.doc.input_file` and `PANDOC_SCRIPT_FILE` need to be resolved before `with_working_directory` changes cwd.
- `pandoc.system.with_environment` *replaces* the entire env, so we copy the current `pandoc.system.environment()` first and overlay `TEXINPUTS` to preserve `PATH` etc.
- Falls back from `quarto.doc.input_file` to `PANDOC_STATE.input_files[1]` for plain-pandoc / older Quarto.
- A small `absolutize` helper resolves relative paths via `\$PWD` / `\$CD`; `pandoc.path.make_absolute` does not exist in any released pandoc, so this helper is needed.

## Test plan

- [x] Existing `example.qmd` still renders both diagrams (regression).
- [x] Smoke test: `\input{shared-styles.tex}` (next to the qmd) resolves and red `myedge` style is applied to the rendered SVG.
- [x] Smoke test: same `shared-styles.tex` placed inside `_extensions/tikz/` is also picked up via the extension-dir entry in `TEXINPUTS`.
- [x] No regression for users without shared files.
- [x] README renders cleanly (heading hierarchy fixed, links resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)