### PR TITLE
Configurable tex engine (lualatex / xelatex)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,13 @@ Here is the source code for a minimal example: [example.qmd](example.qmd).
 
 ## Dependencies
 
-You need both `pdflatex` (TeX Live or MacTeX) and `inkscape` (≥ 1.0)
-installed and on your `PATH`. The filter shells out to `pdflatex` to
+You need a TeX distribution (TeX Live or MacTeX) and `inkscape` (≥ 1.0)
+installed and on your `PATH`. The filter shells out to a LaTeX engine to
 build a PDF and then to Inkscape to convert that PDF to SVG.
+
+`pdflatex` is invoked by default. To use `lualatex` or `xelatex` (e.g.
+for `fontspec` / complex Unicode scripts), set `tikz.tex-engine`
+accordingly — see the configuration reference below.
 
 ## Caching
 
@@ -326,6 +330,11 @@ front-matter or `_quarto.yml`):
   when `cache: true`.
 - `tex-dir` — path, default `tikz-tex`. Where preserved intermediates
   land when `save-tex` is on.
+- `tex-engine` — string, default `pdflatex`. Name of the LaTeX
+  executable to invoke (`pdflatex`, `lualatex`, `xelatex`, or any other
+  TeX engine on your `PATH`). `lualatex` / `xelatex` are useful when
+  you need `fontspec`, Unicode shaping (Arabic, Devanagari, etc.) or
+  modern font features.
 
 Per-block directives (set inside the TikZ code block as `%%| key:
 value` lines, as in [`example.qmd`](example.qmd)):

--- a/_extensions/tikz/tikz.lua
+++ b/_extensions/tikz/tikz.lua
@@ -175,8 +175,8 @@ end
 -- Function to compile TikZ code to SVG
 local function compile_tikz_to_svg(code, user_opts, conf, basename)  -- Added conf and basename parameters
   -- Ensure required dependencies are available
-  if not check_dependency('pdflatex') then
-    error("pdflatex not found. Please install LaTeX to compile TikZ diagrams.")
+  if not check_dependency(conf.tex_engine) then
+    error(conf.tex_engine .. " not found. Please install LaTeX to compile TikZ diagrams.")
   end
   if not check_dependency('inkscape') then
     error("Inkscape not found. Please install Inkscape to convert PDFs to SVG.")
@@ -229,7 +229,7 @@ $body$
       local success, latex_result = pcall(function()
         return pandoc.system.with_environment(env, function()
           return pandoc.pipe(
-            'pdflatex',
+            conf.tex_engine,
             { '-interaction=nonstopmode', tikz_file },
             ''
           )
@@ -298,6 +298,10 @@ local function code_to_figure(conf)
 
     -- Get options from code block
     local dgr_opt = diagram_options(block)
+
+    -- Fold doc-level options that influence compilation into the cache key,
+    -- so e.g. switching from pdflatex to lualatex invalidates cached SVGs.
+    dgr_opt.opt['tex-engine'] = conf.tex_engine
 
     -- Get basename for file naming
     local basename = dgr_opt.filename or pandoc.sha1(block.text)
@@ -425,12 +429,19 @@ local function configure (meta, format_name)
     end
   end
 
+  -- TeX engine. Defaults to pdflatex (the historical behaviour). Users who
+  -- need lualatex/xelatex (e.g. for fontspec, complex Unicode scripts) can
+  -- opt in. Anything matching an executable on PATH is accepted.
+  local tex_engine = conf['tex-engine']
+  tex_engine = tex_engine and pandoc.utils.stringify(tex_engine) or 'pdflatex'
+
   return {
     cache = image_cache and true,
     image_cache = image_cache,
     save_tex = save_tex,
     tex_dir = tex_dir,
     texinputs = build_texinputs(),
+    tex_engine = tex_engine,
   }
 end
 


### PR DESCRIPTION
## Summary

Adds a `tex-engine` option (document- or project-level) so users can
opt into `lualatex` or `xelatex` instead of `pdflatex`. `pdflatex`
remains the default, so this is a no-op for existing users.

```yaml
tikz:
  tex-engine: lualatex
```

The engine name is folded into the per-block cache key, so toggling it
invalidates cached SVGs (no risk of stale output from a different
engine).

## Why

Anyone needing `fontspec`, `babel` for non-Latin scripts (Arabic,
Devanagari, CJK with non-pdftex fonts), or modern font features
currently has to fork the extension. This is the smallest change that
unblocks them.

Inspired by part of #5 — extracted as a focused, default-preserving
PR.

## Test plan

- [x] Default rendering of `example.qmd` (no `tex-engine` set) still
      works with `pdflatex`.
- [x] Smoke test: a minimal qmd with `tex-engine: lualatex` renders
      cleanly through `lualatex`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)