### PR TITLE
Custom LaTeX standalone template (tex-template)

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,13 @@ front-matter or `_quarto.yml`):
   when `cache: true`.
 - `tex-dir` — path, default `tikz-tex`. Where preserved intermediates
   land when `save-tex` is on.
+- `tex-template` — path. If set, the contents of this file replace the
+  built-in `\documentclass[tikz]{standalone}` template. Useful for
+  loading `fontspec`, `babel`, custom colour packages, etc. The
+  template is a [Pandoc template](https://pandoc.org/MANUAL.html#templates),
+  so it must include `$additional-packages$`, `$for(header-includes)$
+  $it$ $endfor$`, and `$body$`. Path is resolved relative to the qmd
+  directory.
 
 Per-block directives (set inside the TikZ code block as `%%| key:
 value` lines, as in [`example.qmd`](example.qmd)):

--- a/_extensions/tikz/tikz.lua
+++ b/_extensions/tikz/tikz.lua
@@ -191,8 +191,11 @@ local function compile_tikz_to_svg(code, user_opts, conf, basename)  -- Added co
       local pdf_file = base_filename .. ".pdf"
       local svg_file = base_filename .. ".svg"
 
-      -- Build the LaTeX document
-      local tikz_template = pandoc.template.compile [[
+      -- Build the LaTeX document. Use the user's template if they supplied
+      -- one via tikz.tex-template; otherwise fall back to the bundled
+      -- standalone template.
+      local tikz_template = pandoc.template.compile(
+        conf.tex_template_content or [[
 \documentclass[tikz]{standalone}
 % \usepackage{tikz} % already loaded by the documentclass
 $additional-packages$
@@ -202,7 +205,7 @@ $endfor$
 \begin{document}
 $body$
 \end{document}
-      ]]
+      ]])
       local meta = {
         ['header-includes'] = { pandoc.RawInline(
           'latex',
@@ -298,6 +301,12 @@ local function code_to_figure(conf)
 
     -- Get options from code block
     local dgr_opt = diagram_options(block)
+
+    -- Fold doc-level options that influence compilation into the cache key,
+    -- so e.g. editing the tex-template invalidates cached SVGs.
+    if conf.tex_template_content then
+      dgr_opt.opt['tex-template-hash'] = pandoc.sha1(conf.tex_template_content)
+    end
 
     -- Get basename for file naming
     local basename = dgr_opt.filename or pandoc.sha1(block.text)
@@ -425,12 +434,29 @@ local function configure (meta, format_name)
     end
   end
 
+  -- Custom LaTeX standalone template. Read once at filter setup so we don't
+  -- pay file I/O per diagram, and so the path resolves against the qmd's
+  -- cwd before with_working_directory changes it.
+  local tex_template_content = nil
+  local tex_template = conf['tex-template']
+  if tex_template then
+    local tex_template_path = absolutize(pandoc.utils.stringify(tex_template))
+    tex_template_content = read_file(tex_template_path)
+    if not tex_template_content then
+      quarto.log.error(
+        "tikz: tex-template not found: " .. tostring(tex_template_path) ..
+        " — falling back to the default template."
+      )
+    end
+  end
+
   return {
     cache = image_cache and true,
     image_cache = image_cache,
     save_tex = save_tex,
     tex_dir = tex_dir,
     texinputs = build_texinputs(),
+    tex_template_content = tex_template_content,
   }
 end
 


### PR DESCRIPTION
## Summary

Adds a `tex-template` option pointing to a Pandoc-template file. When
set, its contents replace the built-in `\documentclass[tikz]{standalone}`
template, so users can load `fontspec`, `babel`, custom colour packages,
etc. without forking the extension.

```yaml
tikz:
  tex-template: my-template.tex
```

The template must include the usual Pandoc placeholders
(`$additional-packages$`, `$for(header-includes)$ $it$ $endfor$`,
`$body$`) so the existing per-block options keep working.

The file is read once at filter setup (no per-diagram I/O), and its
hash is folded into the per-block cache key so editing the template
invalidates cached SVGs.

When unset: no behaviour change.

## Why

Inspired by part of #5 — extracted as a focused, default-preserving
PR. Users with non-Latin scripts, custom font setups, or specific
preamble needs (`xcolor` definitions, custom commands, etc.) currently
have no clean way to inject preamble content beyond the per-block
`additionalPackages` / `header-includes` directives.

## Test plan

- [x] Default rendering of `example.qmd` (no `tex-template` set) still
      uses the bundled template.
- [x] Smoke test: a custom template that defines and applies a custom
      colour produces the expected colour in the rendered SVG
      (verified by grepping for the colour code).
- [x] Editing the custom template invalidates the cache (cache key
      includes the template hash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)