### PR TITLE
feat: tikzjax client-side renderer (renderer: tikzjax)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,39 @@ This should appear in the output as an image
 
 ![](/images/stick-figure.svg)
 
+## Renderers
+
+Two rendering pipelines are available; both consume the same `.tikz` block syntax, so you can switch between them without rewriting blocks.
+
+- **`renderer: latex`** (default) — compiles each block server-side via the configured `tex-engine` (default `pdflatex`) and, for non-PDF outputs, the configured `svg-engine` (default `inkscape`). For PDF output, the intermediate PDF is embedded directly. Works for every output format Quarto supports. Requires a TeX distribution; for non-PDF outputs also a PDF/DVI → SVG converter.
+- **`renderer: tikzjax`** — emits a `<script type="text/tikz">…</script>` tag and loads [TikZJax](https://github.com/artisticat1/obsidian-tikzjax) so the reader's browser renders the diagram client-side via WebAssembly. **No LaTeX or SVG converter needed**, but only works for HTML output and adds ~3 MB of JS/WASM to the first page load. Non-HTML outputs (PDF, docx, …) drop `tikzjax` blocks with a warning — use `renderer: latex` for those.
+
+Pick the renderer document- or project-wide:
+
+```yaml
+tikz:
+  renderer: tikzjax
+```
+
+…or per-block:
+
+````markdown
+```{.tikz}
+%%| renderer: tikzjax
+\begin{tikzpicture}…\end{tikzpicture}
+```
+````
+
+By default the TikZJax assets are loaded from `https://tikzjax.com/v1/`. Override with `tikz.tikzjax-url` if you want to self-host or pin a fork (e.g. [drgrice1/tikzjax](https://github.com/drgrice1/tikzjax)):
+
+```yaml
+tikz:
+  renderer: tikzjax
+  tikzjax-url: https://your.host/path/to/dist
+```
+
+The supplied URL must serve both `tikzjax.js` and `fonts.css` at its root.
+
 ## Sharing styles between diagrams
 
 If you have a `\tikzset` or a `\usepackage` block that you want to reuse
@@ -89,6 +122,10 @@ the intermediate PDF is embedded directly.
 `pdflatex` is invoked by default. To use `lualatex` or `xelatex` (e.g.
 for `fontspec` / complex Unicode scripts), set `tikz.tex-engine`
 accordingly — see the configuration reference below.
+
+Under `renderer: tikzjax` (HTML output only) none of the above is
+required: rendering happens in the reader's browser via WebAssembly.
+See [Renderers](#renderers).
 
 ## Caching
 
@@ -174,6 +211,11 @@ means **Inkscape is not required when you only render to PDF.**
 
 For HTML and other non-PDF formats, the existing `pdflatex` → Inkscape
 → SVG path is used.
+
+Blocks with `renderer: tikzjax` are dropped (with a warning) under PDF
+or any other non-HTML output, since client-side JS can't run there.
+Mixing the two renderers in the same document is fine — only the
+tikzjax-tagged blocks are skipped.
 
 Other features discussed in
 [#5](https://github.com/danmackinlay/quarto_tikz/issues/5) (alternative
@@ -362,6 +404,13 @@ front-matter or `_quarto.yml`):
     keeping text in the rendered SVG selectable. Requires a
     TeX-Live-integrated `dvisvgm`; standalone packages may fail to find
     PostScript prologue files.
+- `renderer` — string, default `latex`. Picks the rendering pipeline:
+  `latex` (server-side `tex-engine` + `svg-engine` chain above) or
+  `tikzjax` (client-side WebAssembly rendering, HTML output only). See
+  [Renderers](#renderers).
+- `tikzjax-url` — string, default `https://tikzjax.com/v1`. Base URL
+  for the TikZJax `tikzjax.js` and `fonts.css` assets when
+  `renderer: tikzjax`. Override to self-host or pin a fork.
 
 Per-block directives (set inside the TikZ code block as `%%| key:
 value` lines, as in [`example.qmd`](example.qmd)):
@@ -375,6 +424,8 @@ value` lines, as in [`example.qmd`](example.qmd)):
 - `additionalPackages` — extra `\usepackage{…}` lines added to the
   preamble of the synthesized LaTeX document.
 - `header-includes` — additional raw LaTeX inserted into the preamble.
+- `renderer` — `latex` or `tikzjax`. Per-block override of the
+  document-level renderer.
 
 Attributes prefixed with `fig-`, `image-`/`img-`, or `opt-` on the code
 block fence are routed to the figure, the image, or the per-block

--- a/_extensions/tikz/_extension.yml
+++ b/_extensions/tikz/_extension.yml
@@ -1,6 +1,6 @@
 title: Tikz
 author: dan mackinlay
-version: 1.1.0
+version: 1.2.0
 quarto-required: ">=1.3.0"
 contributes:
   filters:

--- a/_extensions/tikz/tikz.lua
+++ b/_extensions/tikz/tikz.lua
@@ -60,6 +60,7 @@ local function cachedir ()
 end
 
 local image_cache = nil  -- Path holding the image cache, or `nil` if the cache is not used.
+local tikzjax_assets_injected = false  -- Guards once-per-document injection of TikZJax JS/CSS.
 
 -- Function to parse properties from code comments
 local function properties_from_code (code, comment_start)
@@ -112,6 +113,8 @@ local function diagram_options(cb)
       user_opt['additional-packages'] = value
     elseif attr_name == 'header-includes' then
       user_opt['header-includes'] = value
+    elseif attr_name == 'renderer' then
+      user_opt['renderer'] = value
     elseif attr_name == 'label' then
       fig_attr.id = value
     elseif attr_name == 'name' then
@@ -176,6 +179,51 @@ local function cache_image (hash, options, imgdata, format)
   local filename = cache_key .. '.' .. format
   local imgpath = pandoc.path.join { image_cache, filename }
   write_file(imgpath, imgdata)
+end
+
+-- Inject TikZJax assets (link + script tags) into the document head exactly
+-- once per render. Subsequent calls are no-ops.
+local function inject_tikzjax_assets(conf)
+  if tikzjax_assets_injected then return end
+  tikzjax_assets_injected = true
+  local url = conf.tikzjax_url
+  local html = string.format(
+    '<link rel="stylesheet" href="%s/fonts.css">\n' ..
+    '<script src="%s/tikzjax.js"></script>',
+    url, url
+  )
+  if quarto and quarto.doc and quarto.doc.include_text then
+    quarto.doc.include_text('in-header', html)
+  else
+    quarto.log.warning(
+      "tikz: cannot inject TikZJax assets automatically — " ..
+      "quarto.doc.include_text unavailable. Add the following to your " ..
+      "include-in-header manually:\n" .. html
+    )
+  end
+end
+
+-- Build a `<script type="text/tikz">` block for client-side rendering by
+-- TikZJax. The user's tikzpicture is wrapped in \begin{document}…\end{document}
+-- (TikZJax provides \documentclass{standalone} itself), with any
+-- additionalPackages / header-includes prepended so the same `.tikz` source
+-- works under either renderer.
+local function embed_tikzjax(code, user_opts, conf)
+  inject_tikzjax_assets(conf)
+  local prelude_parts = {}
+  local additional = stringify(user_opts['additional-packages'] or '')
+  if additional ~= '' then
+    table.insert(prelude_parts, additional)
+  end
+  local headers = stringify(user_opts['header-includes'] or '')
+  if headers ~= '' then
+    table.insert(prelude_parts, headers)
+  end
+  local prelude = table.concat(prelude_parts, '\n')
+  local body = (prelude ~= '' and (prelude .. '\n') or '') ..
+    '\\begin{document}\n' .. code .. '\n\\end{document}'
+  return pandoc.RawBlock('html',
+    '<script type="text/tikz">\n' .. body .. '\n</script>')
 end
 
 -- Function to compile TikZ code to either SVG (default) or PDF (passthrough,
@@ -362,6 +410,47 @@ local function code_to_figure(conf)
     dgr_opt.opt['tex-engine'] = conf.tex_engine
     dgr_opt.opt['svg-engine'] = conf.svg_engine
 
+    -- Resolve the effective rendering pipeline. Per-block %%| renderer: …
+    -- overrides the doc/project-level setting. Default 'latex' uses the
+    -- pdflatex/inkscape (or template/svg-engine) chain configured above;
+    -- 'tikzjax' emits a <script type="text/tikz"> for client-side rendering.
+    local renderer = dgr_opt.opt['renderer'] or conf.renderer or 'latex'
+    -- Fold the renderer into the cache key only when non-default, so existing
+    -- latex-pipeline cache entries (written without a 'renderer' key) stay
+    -- valid.
+    if renderer ~= 'latex' then
+      dgr_opt.opt['renderer'] = renderer
+    end
+
+    -- TikZJax path: emit a <script type="text/tikz"> block for the reader's
+    -- browser to render. Only meaningful for HTML-based output (html,
+    -- revealjs, etc.); for anything else, warn and drop the block.
+    if renderer == 'tikzjax' then
+      local is_html_output =
+        (quarto and quarto.doc and quarto.doc.is_format
+          and quarto.doc.is_format('html:js'))
+        or (FORMAT and FORMAT:match('^html'))
+      if not is_html_output then
+        quarto.log.warning(
+          "tikz: renderer 'tikzjax' only renders to HTML; dropping block " ..
+          "for format '" .. tostring(FORMAT) .. "'. " ..
+          "Set renderer: latex (or remove the override) to render this " ..
+          "block under non-HTML output."
+        )
+        return {}  -- remove the block from the output entirely
+      end
+      local raw = embed_tikzjax(block.text, dgr_opt.opt, conf)
+      -- Figure content takes a list of Blocks; RawBlock plugs in directly
+      -- (unlike the LaTeX path's Image, which is an Inline that needs Plain).
+      return dgr_opt.caption and
+          pandoc.Figure(
+            { raw },
+            dgr_opt.caption,
+            dgr_opt['fig-attr']
+          ) or
+          raw
+    end
+
     -- Get basename for file naming
     local basename = dgr_opt.filename or pandoc.sha1(block.text)
 
@@ -538,6 +627,21 @@ local function configure (meta, format_name)
     out_format = 'pdf'
   end
 
+  -- Rendering pipeline. 'latex' (default) runs the server-side TeX +
+  -- svg-engine chain configured above; 'tikzjax' emits a
+  -- <script type="text/tikz"> for client-side WebAssembly rendering in the
+  -- reader's browser. Per-block %%| renderer: … overrides.
+  local renderer = conf.renderer and stringify(conf.renderer) or 'latex'
+
+  -- Base URL serving tikzjax.js and fonts.css. Defaults to the canonical
+  -- tikzjax.com CDN; users can self-host or pin a fork (e.g. drgrice1's).
+  local tikzjax_url = conf['tikzjax-url']
+    and stringify(conf['tikzjax-url'])
+    or 'https://tikzjax.com/v1'
+  -- Strip a trailing slash so concatenation with /fonts.css and /tikzjax.js
+  -- produces a single separator regardless of how the user wrote the URL.
+  tikzjax_url = tikzjax_url:gsub('/+$', '')
+
   return {
     cache = image_cache and true,
     image_cache = image_cache,
@@ -548,6 +652,8 @@ local function configure (meta, format_name)
     tex_engine = tex_engine,
     svg_engine = svg_engine,
     output_format = out_format,
+    renderer = renderer,
+    tikzjax_url = tikzjax_url,
   }
 end
 

--- a/example.qmd
+++ b/example.qmd
@@ -85,3 +85,19 @@ Now, let's look at a more complex example [@fig-example] that uses additional pa
 
 A fancy TikZ example
 :::
+
+
+## TikZJax (client-side) renderer
+
+The same source can be rendered client-side by [TikZJax](https://github.com/artisticat1/obsidian-tikzjax) instead of compiling LaTeX locally. The block below opts in via `%%| renderer: tikzjax` — the rest of the document still uses the default `latex` renderer. The diagram is rendered by the reader's browser when this page is viewed as HTML; under PDF/docx output the block is skipped with a warning.
+
+```{.tikz}
+%%| renderer: tikzjax
+%%| caption: A circle, drawn by TikZJax in your browser
+
+\begin{tikzpicture}
+  \draw (0,0) circle (1cm);
+  \draw (-1.2,0) -- (1.2,0);
+  \draw (0,-1.2) -- (0,1.2);
+\end{tikzpicture}
+```


### PR DESCRIPTION
## Summary

Adds a `renderer` option that picks the rendering pipeline:

- `renderer: latex` (default, unchanged) — server-side `tex-engine` + `svg-engine` chain (or PDF passthrough on PDF output), as configured by #11/#12/#13/#14.
- `renderer: tikzjax` — emits a `<script type="text/tikz">…</script>` tag and loads [TikZJax](https://github.com/artisticat1/obsidian-tikzjax) so the reader's browser renders the diagram client-side via WebAssembly. No LaTeX or SVG converter needed; HTML output only.

Per-block override: `%%| renderer: tikzjax`.

Asset URL is configurable via `tikz.tikzjax-url` (default `https://tikzjax.com/v1`) for self-hosting or pinning a fork (e.g. drgrice1/tikzjax).

## Why

- Lowers the install bar for new users (no TeX Live + Inkscape required for HTML-only workflows).
- Avoids server-side compilation latency for HTML preview.
- Trade-off: ~3 MB JS/WASM on first page load, HTML-only output. So strictly opt-in, defaults preserved.

## Naming

Called `renderer` rather than `engine` to avoid ambiguity with `tex-engine` (#11) and `svg-engine` (#14), which are sub-knobs of the LaTeX pipeline. Hierarchy now reads:

```yaml
tikz:
  renderer: latex          # pipeline (NEW)
  tex-engine: lualatex     # LaTeX binary    (within latex pipeline)
  tex-template: my.tex     # custom standalone template
  svg-engine: dvisvgm      # PDF/DVI -> SVG converter
  # or:
  renderer: tikzjax        # client-side; the *-engine knobs above are unused
  tikzjax-url: https://your.host/dist
```

## Behavior matrix

| `renderer` | HTML output | Non-HTML output (PDF/docx/...) |
|------------|-------------|-------------------------------|
| `latex`    | unchanged   | unchanged (PDF passthrough via #13) |
| `tikzjax`  | emit `<script type="text/tikz">`; inject `tikzjax.js` + `fonts.css` once per doc | log warning, drop block |

## Implementation notes

- `inject_tikzjax_assets` is guarded by a module-level flag so the asset tags appear exactly once per render even with N tikzjax blocks. Uses `quarto.doc.include_text('in-header', …)`.
- `embed_tikzjax` wraps the user's tikzpicture in `\begin{document}…\end{document}` (TikZJax provides `\documentclass{standalone}` itself), prepending any `additionalPackages` / `header-includes` — so the same `.tikz` block source works under either renderer.
- `renderer` is folded into the per-block cache key only when non-default, so existing latex-pipeline cache entries stay valid.
- HTML-format detection uses `quarto.doc.is_format('html:js')` (covers `revealjs` and friends) with a regex fallback.
- Caption / `fig-attr` handling is identical to the latex path, so `@fig-…` cross-references work.

## Test plan

- [x] `quarto render example.qmd --to html`: 2 latex SVGs (regression), 1 `<script type="text/tikz">` block, 1 pair of `<link>`/`<script>` asset tags in `<head>`, figcaption rendered for the tikzjax block.
- [x] `quarto render example.qmd --to pdf`: warning fires (`renderer 'tikzjax' only renders to HTML; dropping block for format 'latex'`), tikzjax block dropped, latex blocks render via #13's PDF-passthrough path. PDF builds successfully.
- [ ] Self-hosted assets: set `tikz.tikzjax-url: file:///some/local/path` and confirm the injected tags reflect the override.
- [ ] revealjs render: confirm `quarto.doc.is_format('html:js')` matches and the script tag is emitted.

## Files

- `_extensions/tikz/tikz.lua` — `+106` (two new functions, dispatcher in `code_to_figure`, two new conf fields)
- `_extensions/tikz/_extension.yml` — version 1.1.0 → 1.2.0
- `README.md` — new "Renderers" section + tikzjax notes in Dependencies / PDF output / Configuration reference
- `example.qmd` — adds a `%%| renderer: tikzjax` demo block

🤖 Generated with [Claude Code](https://claude.com/claude-code)