### PR TITLE
Include basename in cache filenames (closes #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,14 @@ By default, cached SVGs are written to a per-user cache directory:
   `~/.cache/tikz-diagram-filter/` if `XDG_CACHE_HOME` is unset).
 - Windows: `%USERPROFILE%\.cache\tikz-diagram-filter\`.
 
-Cache keys are the SHA1 of the TikZ code together with any per-block
-options, so editing either invalidates the entry.
+Cache files are named `<basename>.<short-hash>.<ext>` (e.g.
+`stick-figure.318b4ef1.svg`). The basename comes from the block's
+`%%| filename:` directive (or `tikz` if you didn't set one), and the
+short hash is derived from the TikZ code plus per-block options, the
+TeX engine, the SVG engine, the template, and the output format —
+toggling any of those produces a different cache file. A `ls` of the
+cache directory is therefore enough to tell at a glance which diagram
+in which document each entry came from.
 
 You can override the location with `tikz.cache-dir: <path>`, but doing so
 scatters per-directory cache folders across the tree. **Leaving
@@ -159,9 +165,6 @@ Cleanup today is manual — `rm -rf` the cache dir occasionally, or
 
 Known follow-ups (PRs welcome):
 
-- [#9](https://github.com/danmackinlay/quarto_tikz/issues/9) — include
-  the diagram basename in the cache filename so a directory listing is
-  human-diagnosable.
 - [#10](https://github.com/danmackinlay/quarto_tikz/issues/10) — touch
   cache entries on hit so an external `find -mtime`-based GC reflects
   actual last use.

--- a/_extensions/tikz/_extension.yml
+++ b/_extensions/tikz/_extension.yml
@@ -1,6 +1,6 @@
 title: Tikz
 author: dan mackinlay
-version: 1.2.0
+version: 1.2.1
 quarto-required: ">=1.3.0"
 contributes:
   filters:

--- a/_extensions/tikz/tikz.lua
+++ b/_extensions/tikz/tikz.lua
@@ -153,15 +153,33 @@ local function mime_for_format(format)
   return 'image/svg+xml'
 end
 
+-- Construct a cache filename of the form `<label>.<short-hash>.<format>`.
+-- Including the basename makes a directory listing diagnosable (you can
+-- tell which diagram produced which file at a glance), while the short
+-- hash preserves cache-key uniqueness across code/option changes.
+--
+-- When the caller-supplied basename is the auto-generated SHA1 of the
+-- block's code (40 hex chars), we use a short literal label instead;
+-- repeating the full content hash inside the filename adds no diagnostic
+-- value and bloats the listing.
+local function cache_filename(basename, hash, options, format)
+  local cache_key = pandoc.sha1(hash .. stringify(options))
+  local short = cache_key:sub(1, 8)
+  local label = basename or 'tikz'
+  if #label == 40 and label:match('^[0-9a-f]+$') then
+    label = 'tikz'
+  end
+  return label .. '.' .. short .. '.' .. format
+end
+
 -- Function to get cached image
-local function get_cached_image (hash, options, format)
+local function get_cached_image (basename, hash, options, format)
   if not image_cache then
     return nil
   end
-  -- Include options in the hash to ensure cache invalidation when options change
-  local cache_key = pandoc.sha1(hash .. stringify(options))
-  local filename = cache_key .. '.' .. format
-  local imgpath = pandoc.path.join { image_cache, filename }
+  local imgpath = pandoc.path.join {
+    image_cache, cache_filename(basename, hash, options, format),
+  }
   local imgdata = read_file(imgpath)
   if imgdata then
     return imgdata, mime_for_format(format)
@@ -170,14 +188,14 @@ local function get_cached_image (hash, options, format)
 end
 
 -- Function to cache image
-local function cache_image (hash, options, imgdata, format)
+local function cache_image (basename, hash, options, imgdata, format)
   -- Do nothing if caching is disabled or not possible.
   if not image_cache then
     return
   end
-  local cache_key = pandoc.sha1(hash .. stringify(options))
-  local filename = cache_key .. '.' .. format
-  local imgpath = pandoc.path.join { image_cache, filename }
+  local imgpath = pandoc.path.join {
+    image_cache, cache_filename(basename, hash, options, format),
+  }
   write_file(imgpath, imgdata)
 end
 
@@ -459,7 +477,7 @@ local function code_to_figure(conf)
     local imgdata, imgtype = nil, nil
     local out_format = conf.output_format
     if conf.cache then
-      imgdata, imgtype = get_cached_image(hash, dgr_opt.opt, out_format)
+      imgdata, imgtype = get_cached_image(basename, hash, dgr_opt.opt, out_format)
     end
 
     if not imgdata or not imgtype then
@@ -476,7 +494,7 @@ local function code_to_figure(conf)
       imgdata, imgtype = result, mime or mime_for_format(out_format)
 
       -- Cache the image
-      cache_image(hash, dgr_opt.opt, imgdata, out_format)
+      cache_image(basename, hash, dgr_opt.opt, imgdata, out_format)
     end
 
     -- Use the block's filename attribute or create a new name by hashing the image content.


### PR DESCRIPTION
## Summary

Replaces opaque cache filenames like
`44e62e25469880ad89a9df212891be7037f22da9.svg` with diagnosable ones
like `stick-figure.318b4ef1.svg`. A directory listing of the cache
now tells you which diagram in which document produced each entry.

```
$ ls ~/.cache/tikz-diagram-filter/
mech-newcomb.44e62e25.svg
stick-figure.318b4ef1.svg
my-fancy-diagram.7a3b8e2c.pdf
tikz.da6b4880.svg                  # an unnamed block
```

Cache-key uniqueness is preserved by the 8-char SHA1 suffix
(derived from TikZ code + per-block options + tex-engine + svg-engine
+ template + output format, same as before — just truncated).

When a block has no `%%| filename:` directive (so basename falls
back to a content SHA1), the label is collapsed to the literal
`tikz` to avoid bloating cache filenames with a duplicate full hash.

Bumps version to `1.2.1`.

## Closes

#9

## Test plan

- [x] Render a project with caching on; cache directory shows
      `<basename>.<8hex>.svg` filenames for both named and unnamed
      blocks.
- [x] Second render of the same document is a cache hit (same files,
      no recompile).
- [x] `example.qmd` renders cleanly (no regression).

## One-time effect

Existing cache files in users' caches become orphaned (the lookup
key changed, so old entries are no longer found). They're harmless —
just waste a little disk — and an `rm -rf <cache-dir>` cleans them
up. Subsequent renders rebuild the cache with the new filenames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)