### PR TITLE
docs: note that doc-level tikz: blocks replace project-level config

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,18 @@ Anyway, you need to ensure that both `pdflatex` and `inkscape` are installed and
 Document- or project-level options (set under `tikz:` in the YAML
 front-matter or `_quarto.yml`):
 
+> **Note on document- vs project-level merging.** A `tikz:` block in a
+> document's front-matter **replaces** the project-level `tikz:` block
+> wholesale — Quarto does not deep-merge user-defined config keys. So a
+> per-doc `tikz: { cache: true }` meant as a benign repeat will drop
+> every other setting (`cache-dir`, `svg-engine`, `renderer`, …) from
+> `_quarto.yml` and silently fall back to the filter defaults. If you
+> need a per-doc override, repeat every project-level setting you still
+> want; otherwise, omit the `tikz:` block at the doc level entirely and
+> let project-level settings apply. (Note that `filters: - tikz` is
+> separate — that line is required per-doc and unaffected by this
+> merging behaviour.)
+
 - `cache` — boolean, default `false`. Enable the on-disk SVG cache.
 - `cache-dir` — path. Defaults to `$XDG_CACHE_HOME/tikz-diagram-filter`
   (or the per-user cache equivalent on your platform). Override only if


### PR DESCRIPTION
## Why

Got bitten by this with a project that had `svg-engine: pdftocairo` and `cache-dir: ../.tikz-cache` in `_quarto.yml`, plus `tikz: { cache: true }` left over at doc level in several qmds (originally added when there was no project-level `tikz:` block). Renders silently fell back to inkscape, wrote to `~/.cache/tikz-diagram-filter/`, and produced a confusingly partial cache.

The cause is Quarto's general config-merge behaviour: it deep-merges keys it understands (`format:`, `execute:`, etc.) but shallow-replaces unknown keys like `tikz:`. That's a sensible default from Quarto's POV (it can't know how to merge arbitrary user-defined keys), but the failure mode is invisible — the filter just sees a sparse config and uses defaults for everything not mentioned at doc level.

## What

Adds a short admonition to the **Configuration reference** section, right after the lead-in that mentions both project- and doc-level `tikz:` blocks. The note explains the replace-not-merge behaviour, gives the typical foot-gun example, and tells the reader the two valid patterns: omit the doc-level `tikz:` block entirely, or repeat every setting that should still apply.

Also clarifies that `filters: - tikz` is separate (still required per-doc, not affected by the merge behaviour) — easy to confuse.

## Alternatives considered

A code-level fix where the filter reads `quarto.project.metadata.tikz` and merges with `meta.tikz` itself would also solve this, but it would diverge from how every other Quarto extension handles config and depend on Quarto's project-metadata API. A docs note seemed like the right scope: cheap, doesn't introduce new behaviour, and would have caught me before I lost an afternoon.

(Companion to the existing #6/#9/#14 work that's already shipped — same theme of "make the extension less surprising on minimal/CI environments".)