### PR TITLE
docs: post-audit cleanups (README staleness, dead var, comment drift)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,12 +45,17 @@ luac.out
 *.x86_64
 *.hex
 
-## rendering cruft
+## rendering cruft (intermediate files left behind by save-tex
+## debugging or by ad-hoc local renders)
 *.aux
 *.dvi
 *.log
 /images/
 *.fdb_latexmk
 *.fls
-*.tex
-_tikz_cache
+# Project-level rendering output:
+/tikz-tex/
+# Don't ignore .tex files inside _extensions/tikz/ (we may ship sample
+# templates there). Only ignore intermediate .tex output produced by
+# save-tex into the project root or local dirs that aren't extensions.
+/*.tex

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ The supplied URL must serve both `tikzjax.js` and `fonts.css` at its root.
 If you have a `\tikzset` or a `\usepackage` block that you want to reuse
 across many diagrams, you can put it in a separate file alongside your
 `.qmd` and `\input` (or `\usepackage`) it from each TikZ block. The
-extension sets `TEXINPUTS` before invoking `pdflatex` so that lookups
-resolve in this order:
+extension sets `TEXINPUTS` before invoking the TeX engine so that
+lookups resolve in this order:
 
 1. The directory containing the source `.qmd`.
 2. The extension's own directory (`_extensions/tikz/`), so that you can
@@ -187,9 +187,9 @@ justify right now.
 
 When a TikZ block silently produces something wrong (or fails to
 compile), the quickest way to diagnose it is to look at the intermediate
-`.tex`, `.pdf` and `.log` files that `pdflatex` actually saw. The
-filter can preserve those for inspection, but **only with caching
-switched off** (see below):
+files (`.tex`, `.pdf` or `.dvi`, and `.log`) the TeX engine actually
+saw. The filter can preserve those for inspection, but **only with
+caching switched off** (see below):
 
 ```yaml
 # in the offending document's front-matter, temporarily
@@ -199,9 +199,9 @@ tikz:
   tex-dir: tikz-tex   # any path; defaults to 'tikz-tex'
 ```
 
-Re-render the document and inspect
-`<tex-dir>/<filename>/<filename>.{tex,pdf,svg,log}`. Running `pdflatex
-<filename>.tex` by hand from inside that directory reproduces the exact
+Re-render the document and inspect the contents of
+`<tex-dir>/<filename>/`. Running your configured TeX engine (default
+`pdflatex`) by hand from inside that directory reproduces the exact
 compilation, and the `.log` is usually enough to spot the problem.
 
 `cache: true` and `save-tex: true` are mutually exclusive: a cache hit
@@ -217,13 +217,16 @@ your `tex-dir` to `.gitignore`.
 ## PDF output
 
 When the Quarto output format is PDF (e.g. `format: pdf`), the
-extension skips the Inkscape conversion step and embeds each TikZ
+extension skips the SVG conversion step entirely and embeds each TikZ
 diagram's intermediate PDF directly via `\includegraphics`. This
 preserves vector fidelity and fonts in the rendered document, and
-means **Inkscape is not required when you only render to PDF.**
+means **no SVG converter is required when you only render to PDF.**
 
-For HTML and other non-PDF formats, the existing `pdflatex` → Inkscape
-→ SVG path is used.
+For HTML and other non-PDF formats, the TeX engine's PDF (or DVI, if
+you've set `svg-engine: dvisvgm`) is run through the configured SVG
+converter to produce an embedded SVG. See the
+[configuration reference](#configuration-reference) for `tex-engine`,
+`svg-engine`, and `svg-command`.
 
 Blocks with `renderer: tikzjax` are dropped (with a warning) under PDF
 or any other non-HTML output, since client-side JS can't run there.
@@ -376,10 +379,14 @@ To include additional LaTeX packages, use the `additionalPackages` option within
 
 ### Dependency Changes
 
-The extension now uses `pdflatex` and `inkscape` instead of the older `dvisvgm` and `ghostscript`.
-There were certain advantages to that renderer; I wonder if we should support switchable backends?
-
-Anyway, you need to ensure that both `pdflatex` and `inkscape` are installed and accessible in your system's PATH. If not, install them to avoid rendering issues.
+The extension defaults to `pdflatex` for compilation and `inkscape`
+for SVG conversion. Both are now configurable via `tikz.tex-engine`
+and `tikz.svg-engine` (the latter also supports `dvisvgm` and
+`pdftocairo`; for anything else, `tikz.svg-command` is an arbitrary
+external command escape hatch). See the
+[configuration reference](#configuration-reference) and the
+[Recipes](#recipes) section. When you only render to PDF, no SVG
+converter is required at all.
 
 ## Configuration reference
 
@@ -614,5 +621,6 @@ After spending 2 days of my life getting this working, I found that [there is a 
 There is a bigger and more powerful system [pandoc-ext/diagram](https://github.com/pandoc-ext/diagram/tree/main) which you might prefer to use instead.
 It can “Generate diagrams from embedded code; supports Mermaid, Dot/GraphViz, PlantUML, Asymptote, and TikZ”.
 
-~~The distinction between this and their project is that for this filter inkscape is not a dependency, and we can use the `dvisvgm` backend, but OTOH, their package is better tested, more capable and more general.~~
-This distinction between this project and theirs is that we handle Figures IMO sanely and also are simpler.
+The distinction between this project and theirs is that we handle
+Figures more straightforwardly and the filter is simpler. Both
+projects let you pick between Inkscape, `dvisvgm`, and other backends.

--- a/README.md
+++ b/README.md
@@ -386,6 +386,18 @@ Anyway, you need to ensure that both `pdflatex` and `inkscape` are installed and
 Document- or project-level options (set under `tikz:` in the YAML
 front-matter or `_quarto.yml`):
 
+> **Note on document- vs project-level merging.** A `tikz:` block in a
+> document's front-matter **replaces** the project-level `tikz:` block
+> wholesale — Quarto does not deep-merge user-defined config keys. So a
+> per-doc `tikz: { cache: true }` meant as a benign repeat will drop
+> every other setting (`cache-dir`, `svg-engine`, `renderer`, …) from
+> `_quarto.yml` and silently fall back to the filter defaults. If you
+> need a per-doc override, repeat every project-level setting you still
+> want; otherwise, omit the `tikz:` block at the doc level entirely and
+> let project-level settings apply. (Note that `filters: - tikz` is
+> separate — that line is required per-doc and unaffected by this
+> merging behaviour.)
+
 - `cache` — boolean, default `false`. Enable the on-disk SVG cache.
 - `cache-dir` — path. Defaults to `$XDG_CACHE_HOME/tikz-diagram-filter`
   (or the per-user cache equivalent on your platform). Override only if

--- a/_extensions/tikz/tikz.lua
+++ b/_extensions/tikz/tikz.lua
@@ -249,7 +249,9 @@ end
 local function compile_tikz_to_svg(code, user_opts, conf, basename)  -- Added conf and basename parameters
   -- Ensure required dependencies are available
   if not check_dependency(conf.tex_engine) then
-    error(conf.tex_engine .. " not found. Please install LaTeX to compile TikZ diagrams.")
+    error(conf.tex_engine .. " not found on PATH. Install it, or set " ..
+      "tikz.tex-engine to a TeX engine you do have (pdflatex, lualatex, " ..
+      "xelatex, …).")
   end
   -- The svg converter is only needed when we actually convert to SVG. For
   -- PDF output we embed the intermediate PDF directly and nothing here is
@@ -310,8 +312,9 @@ $body$
       -- onto a copy of the current env to preserve PATH and friends.
       local env = pandoc.system.environment()
       env.TEXINPUTS = conf.texinputs
-      -- dvisvgm consumes a DVI file, so ask pdflatex for DVI output in that
-      -- case. Otherwise (inkscape) we want the default PDF output.
+      -- dvisvgm consumes a DVI file, so ask the TeX engine for DVI output
+      -- in that case. Every other path (inkscape, pdftocairo, custom
+      -- svg-command, PDF passthrough) consumes the default PDF output.
       local latex_args = { '-interaction=nonstopmode' }
       if conf.svg_engine == 'dvisvgm' then
         table.insert(latex_args, '-output-format=dvi')
@@ -581,10 +584,11 @@ local function build_texinputs()
   return table.concat(parts, sep) .. sep
 end
 
--- Function to configure the filter based on metadata and format
-local function configure (meta, format_name)
+-- Function to configure the filter based on document metadata. Reads
+-- top-level `tikz:` config and produces a normalized `conf` table that the
+-- per-block code path consumes.
+local function configure (meta)
   local conf = meta.tikz or {}
-  local format = format_name
   meta.tikz = nil  -- Remove tikz metadata to avoid processing it further
 
   -- cache for image files
@@ -729,7 +733,7 @@ end
 return {
   {
     Pandoc = function(doc)
-      local conf = configure(doc.meta, FORMAT)
+      local conf = configure(doc.meta)
       return doc:walk {
         CodeBlock = code_to_figure(conf),
       }


### PR DESCRIPTION
## Summary

Post-feature-burst cleanup pass surfaced during the audit. No behaviour change in the filter.

### `tikz.lua`

- Drop the unused `local format = format_name` and the unused `format_name` parameter on `configure()`.
- Update the stale `-- Otherwise (inkscape)` comment at the LaTeX invocation: every non-dvisvgm path (inkscape / pdftocairo / svg-command / PDF passthrough) consumes PDF.
- Improve the tex-engine missing-dependency error: previous "Please install LaTeX" was misleading when the user has set `tikz.tex-engine: lualatex` and only `lualatex` is missing.

### `README.md`

Sweep through stale `pdflatex`-by-name / `Inkscape`-by-name references in sections where the underlying behaviour is engine-agnostic now:

- **Sharing styles between diagrams** — TEXINPUTS is set before invoking *the TeX engine*, not specifically pdflatex.
- **Debugging a diagram** — describe the intermediate files (`.tex` / `.pdf` or `.dvi` / `.log`) as the TeX engine's, not pdflatex's. Reproducer step says "your configured TeX engine".
- **PDF output** — drop "Inkscape conversion step" (could be any configured engine); replace "the existing `pdflatex` → Inkscape → SVG path" with an engine-agnostic description plus a pointer to the configuration reference.
- **Upgrading > Dependency Changes** — completely rewrite. The old text said the extension "now uses pdflatex and inkscape instead of the older dvisvgm and ghostscript", which is now false (we re-added dvisvgm support in #14) and contained a musing ("I wonder if we should support switchable backends?") that's obsolete since #14 / #19.
- **Credits** — drop the strikethrough sentence; rewrite the live one to mention all current backends.

Default-named mentions (`tex-engine` defaults to `pdflatex`, `svg-engine` defaults to `inkscape`) and recipe-specific mentions (Inkscape-free CI; non-Latin scripts) are kept since they're naming the actual default or describing a specific tool's properties.

### `.gitignore`

- Replace overly-broad `*.tex` (would silently ignore any sample template we ever ship in `_extensions/tikz/`) with `/*.tex` (root-only).
- Add `/tikz-tex/` for save-tex debugging output.
- Drop `_tikz_cache` (stale cache-dir name; never used in committed code).

## Out of scope (tracked separately)

- The latent correctness bug — cache key uses unsorted Lua table iteration — is tracked as #21. Not fixed here because the fix changes cache filenames (one-time invalidation) and deserves its own PR with a version bump.
- The `quarto.doc.is_format` vs `quarto.doc.isFormat` discrepancy in the tikzjax HTML detection — small but a real code change rather than a doc fix; can be a follow-up.
- `compile_tikz_to_svg` is 175 lines and would benefit from extracting helpers — not urgent, deferred.

## Test plan

- [x] `example.qmd` renders cleanly (no filter behaviour change in this PR).
- [x] All remaining `pdflatex` / `Inkscape` mentions in the README are appropriate (defaults, recipe contexts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
