### PR TITLE
Metadata clarity: captions/cross-refs docs + %%| precedence over fence attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,21 @@ Now
 ```
 ````
 
+The fence-attribute form still works for backward compatibility, but
+**if you set the same option both ways, the `%%|` directive wins** and
+the fence attribute is ignored (with a warning). For example:
+
+````markdown
+```{.tikz filename='bayesnet-3'}
+%%| filename: bayesnet-4
+% → renders as bayesnet-4; a warning notes bayesnet-3 was ignored
+```
+````
+
+Don't set an option in both places. Pick the `%%|` form (it's the
+canonical syntax and matches Quarto's cell-options convention) and
+delete any leftover fence attribute.
+
 ### Figure Attributes Handling
 
 Figure attributes such as `id` and `class` can be set with the
@@ -510,7 +525,11 @@ front-matter or `_quarto.yml`):
   `renderer: tikzjax`. Override to self-host or pin a fork.
 
 Per-block directives (set inside the TikZ code block as `%%| key:
-value` lines, as in [`example.qmd`](example.qmd)):
+value` lines, as in [`example.qmd`](example.qmd)). These may also be
+given as code-block fence attributes (`{.tikz filename=…}`, the
+deprecated pre-1.0 form) — but if a key is set both ways the `%%|`
+directive wins and the fence attribute is ignored with a warning, so
+don't set the same option in both places:
 
 - `filename` — basename for the generated `.tex`/`.pdf`/`.svg`. Defaults
   to a hash of the code.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,62 @@ This should appear in the output as an image
 
 ![](/images/stick-figure.svg)
 
+## Captions and cross-references
+
+There are two ways to give a diagram a caption, and they exist for
+**different goals** — pick based on whether you need to refer to the
+figure from prose.
+
+**1. `%%| caption:` inside the block — for a caption only.**
+
+````markdown
+```{.tikz}
+%%| filename: stick-figure
+%%| caption: A Stick Figure
+
+\begin{tikzpicture}...\end{tikzpicture}
+```
+````
+
+The filter wraps the image in a figure with that caption. This is the
+simplest option and is all you need if you just want a caption under
+the diagram. The figure's `id`/`class` come from `%%| fig-attr:` /
+`label:` / `name:`, but those attributes don't reliably survive
+Quarto's float handling, so a figure made this way is **not
+dependably cross-referenceable** with `@fig-…`.
+
+**2. Quarto's native fenced div — for `@fig-…` cross-references.**
+
+````markdown
+::: {#fig-stick}
+```{.tikz}
+%%| filename: stick-figure
+\begin{tikzpicture}...\end{tikzpicture}
+```
+
+A Stick Figure
+:::
+````
+
+Here Quarto owns the float, so `@fig-stick` resolves correctly. Use
+this whenever you need to reference the figure in text. This is the
+pattern the bundled [`example.qmd`](example.qmd) uses.
+
+| You want… | Use |
+|---|---|
+| Just a caption under the diagram | `%%\| caption:` |
+| A `@fig-…` cross-reference in prose | Quarto fenced div `::: {#fig-…}` |
+| Both caption *and* cross-reference | Fenced div, with the caption as the div's last line |
+
+> [!WARNING]
+> **Don't do both at once.** If you set `%%| caption:` *and* wrap the
+> same block in a `::: {#fig-…}` div that also carries a caption line,
+> the filter emits a figure (because of `%%| caption:`) which Quarto
+> then nests inside *its* figure — you get a figure-within-a-figure
+> with a doubled or empty caption. When you use the fenced div, leave
+> `%%| caption:` out of the block and let the div's last line be the
+> caption.
+
 ## Renderers
 
 Two rendering pipelines are available; both consume the same `.tikz` block syntax, so you can switch between them without rewriting blocks.
@@ -238,22 +294,13 @@ separately. PRs welcome.
 ## Known bugs
 
 Figure attributes set inside the TikZ block (via `%%| fig-attr:`,
-`label:`, `name:`) don't always survive the round-trip into the rendered
-output. The reliable pattern is to wrap the block in a Quarto fenced
-div, which is what the bundled [`example.qmd`](example.qmd) does:
-
-````markdown
-::: {#fig-my-diagram}
-```{.tikz}
-%%| filename: my-diagram
-\begin{tikzpicture}…\end{tikzpicture}
-```
-
-Caption goes here.
-:::
-````
-
-This makes `@fig-my-diagram` cross-references work correctly.
+`label:`, `name:`) don't always survive the round-trip into the
+rendered output, so a figure captioned with `%%| caption:` is not
+dependably cross-referenceable. The reliable pattern for `@fig-…`
+references is to wrap the block in a Quarto fenced div instead — see
+[Captions and cross-references](#captions-and-cross-references) above
+for both methods, when to use each, and the figure-in-a-figure pitfall
+to avoid.
 
 
 ## Upgrading from Previous Versions
@@ -309,10 +356,8 @@ Now
 
 ### Figure Attributes Handling
 
-Figure attributes such as `id` and `class` are now set using the `fig-attr` option within the code block comments.
-I think? TBH have not actually tested this
-
-Use `fig-attr` to define figure attributes. For example:
+Figure attributes such as `id` and `class` can be set with the
+`fig-attr` option inside the code block:
 
 ````markdown
 ```{.tikz}
@@ -324,9 +369,13 @@ Use `fig-attr` to define figure attributes. For example:
 ```
 ````
 
-But actually figure attributes in Quarto are dark magic.
-Life is easier if we simply use their fenced divs and give them a name like `#fig-my-diagram`.
-See [example.qmd](example.qmd).
+…but attributes set this way don't reliably survive Quarto's float
+handling, so for anything you need to cross-reference, prefer the
+fenced-div pattern. See
+[Captions and cross-references](#captions-and-cross-references) for the
+full picture (both methods, when to use each, and the
+figure-in-a-figure pitfall). The bundled [`example.qmd`](example.qmd)
+uses the fenced-div form:
 
 ````
 ::: {#fig-example .test-class}
@@ -465,10 +514,13 @@ value` lines, as in [`example.qmd`](example.qmd)):
 
 - `filename` — basename for the generated `.tex`/`.pdf`/`.svg`. Defaults
   to a hash of the code.
-- `caption` — figure caption (Markdown).
+- `caption` — figure caption (Markdown). Produces a caption only, not
+  a reliable cross-reference target — see
+  [Captions and cross-references](#captions-and-cross-references).
 - `alt` — image alt text.
 - `fig-attr:` — nested block of Pandoc figure attributes (`id`,
-  `class`, etc.).
+  `class`, etc.). Not dependably honoured for cross-references; see
+  [Captions and cross-references](#captions-and-cross-references).
 - `additionalPackages` — extra `\usepackage{…}` lines added to the
   preamble of the synthesized LaTeX document.
 - `header-includes` — additional raw LaTeX inserted into the preamble.

--- a/_extensions/tikz/_extension.yml
+++ b/_extensions/tikz/_extension.yml
@@ -1,6 +1,6 @@
 title: Tikz
 author: dan mackinlay
-version: 1.3.0
+version: 1.4.0
 quarto-required: ">=1.3.0"
 contributes:
   filters:

--- a/_extensions/tikz/tikz.lua
+++ b/_extensions/tikz/tikz.lua
@@ -89,9 +89,25 @@ end
 
 -- Function to process code block attributes and options
 local function diagram_options(cb)
+  -- The `%%| key: value` comment directives are the canonical, current
+  -- syntax (and match Quarto's cell-options convention). Code-block fence
+  -- attributes (`{.tikz filename=…}`) are the deprecated pre-1.0 form. When
+  -- a key is given both ways, the %%| directive wins; we only let a fence
+  -- attribute through if the %%| form didn't set that key, and we warn on
+  -- any genuine conflict so the silent override becomes visible.
   local attribs = properties_from_code(cb.text, '%%')
   for key, value in pairs(cb.attributes) do
-    attribs[key] = value
+    if attribs[key] == nil then
+      attribs[key] = value
+    elseif attribs[key] ~= value then
+      quarto.log.warning(
+        "tikz: '" .. key .. "' is set both as a code-block fence " ..
+        "attribute (" .. tostring(value) .. ") and via the canonical " ..
+        "%%| " .. key .. ": directive (" .. tostring(attribs[key]) ..
+        "). The %%| directive wins; the fence attribute is ignored. " ..
+        "Remove one to silence this warning."
+      )
+    end
   end
 
   local alt


### PR DESCRIPTION
## Summary

Two related fixes around **how diagram metadata is specified and which mechanism is authoritative**. Originally a docs-only clarity pass; now also fixes a silent precedence footgun in the same area (folded in at the maintainer's request — same class of problem).

### 1. Captions & cross-references (docs)

The guidance was scattered across three sections and never stated the two methods' distinct goals or warned about combining them. Consolidated into a new **"Captions and cross-references"** section right after "Using":

- `%%| caption:` → caption only, **not** a dependable `@fig-…` target
- Quarto fenced div `::: {#fig-…}` → use when you need cross-references
- decision table + a `[!WARNING]` callout: don't set `%%| caption:` *and* wrap the block in a captioned `::: {#fig-…}` div (figure-in-a-figure → doubled/empty caption)

"Known bugs" and "Upgrading > Figure Attributes Handling" now defer to the canonical section; the drafty "dark magic" / "TBH have not actually tested this" asides are gone; the config reference cross-links to it.

### 2. `%%|` directives win over fence attributes (behaviour fix)

Previously, setting an option both as a fence attribute (`{.tikz filename='bayesnet-3'}`) and via `%%| filename: bayesnet-4` let the **deprecated** fence form silently overwrite the **canonical** `%%|` value — the opposite of what the docs prescribe.

`diagram_options` now:

- lets a fence attribute through only if the `%%|` form didn't set that key (fence-only usage stays backward compatible),
- keeps the `%%|` value on conflict,
- `quarto.log.warning`s with both values so the override is visible,
- stays silent when both sides have the same value (not a real conflict).

Documented in the "Option Specification Syntax" upgrade section (with the `bayesnet` example) and the config-reference per-block intro.

**Version bump 1.3.0 → 1.4.0** — behaviour change. For the (deprecated) fence-attribute population this changes which cache *file label* is used, orphaning the old one; harmless, rebuilds on next render.

## Test plan

- [x] Conflict (`filename` both ways) → `%%|` value wins (`bayesnet-4.svg`), warning fired.
- [x] Fence-only attribute (no `%%|`) → still works, no warning (backward compat).
- [x] Same value both ways → no warning.
- [x] `example.qmd` renders cleanly, no spurious warning (it uses only `%%|`).
- [x] New "Captions and cross-references" anchor links resolve; `[!WARNING]` + escaped-pipe table render on GitHub.

## Notes

- Rebased onto current `main` (picked up #20). Force-pushed.
- Docs commit and behaviour commit are kept separate for reviewability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
